### PR TITLE
revert imports due to vscode incorrectly classifying tensorflow as unresolved

### DIFF
--- a/core/model.py
+++ b/core/model.py
@@ -1,12 +1,11 @@
 import os
-import math
 import numpy as np
 import datetime as dt
 from numpy import newaxis
 from core.utils import Timer
-from tensorflow.python.keras.layers import Dense, Activation, Dropout, LSTM
-from tensorflow.python.keras.models import Sequential, load_model
-from tensorflow.python.keras.callbacks import EarlyStopping, ModelCheckpoint
+from tensorflow.keras.layers import Dense, Activation, Dropout, LSTM
+from tensorflow.keras.models import Sequential, load_model
+from tensorflow.keras.callbacks import EarlyStopping, ModelCheckpoint
 
 
 class Model:

--- a/core/utils.py
+++ b/core/utils.py
@@ -15,6 +15,7 @@ class Timer:
         # Stop the timer and print the elapsed time
         if self.start_dt is None:
             raise ValueError("Timer was not started. Call start() before stop().")
+        
         end_dt = dt.datetime.now()
         elapsed_time = end_dt - self.start_dt
         print(f"Time Taken: {elapsed_time}")


### PR DESCRIPTION
NOTE: Environment Variable `CUDA_VISIBLE_DEVICES` should be set to `-1`

This may not be an issue on windows, however I was unable to get linux to run this code on my laptop GPU